### PR TITLE
fix: Manage middle mouse click and CTRL+click on rows, fixes #10

### DIFF
--- a/_includes/addon_table.html
+++ b/_includes/addon_table.html
@@ -103,7 +103,7 @@
                     if (e.target.tagName.toLowerCase() !== 'a' && url) {
                         if(e.which === 2 || e.ctrlKey || e.metaKey) {
                             window.open(url);
-                        } else {
+                        } else if (e.which === 1) {
                             window.location.href = url;
                         }                        
                     }

--- a/_includes/addon_table.html
+++ b/_includes/addon_table.html
@@ -100,7 +100,7 @@
 
                 // Assign click event to the entire row
                 $(row).on('mousedown', function(e) {
-                    if (url) {
+                    if (e.target.tagName.toLowerCase() !== 'a' && url) {
                         if(e.which === 2 || e.ctrlKey || e.metaKey) {
                             window.open(url);
                         } else {

--- a/_includes/addon_table.html
+++ b/_includes/addon_table.html
@@ -99,9 +99,13 @@
                 var url = $(row).find('.name').data('url');
 
                 // Assign click event to the entire row
-                $(row).click(function() {
+                $(row).on('mousedown', function(e) {
                     if (url) {
-                        window.location.href = url;
+                        if(e.which === 2 || e.ctrlKey || e.metaKey) {
+                            window.open(url);
+                        } else {
+                            window.location.href = url;
+                        }                        
                     }
                 });
                 $(row).css('cursor','pointer');


### PR DESCRIPTION
## The Issue

On a list of addons, it's not possible to 'Mouse middle click' or 'CTRL+click' or even 'Right click + open in new tab'.
We can only 'Left click' and have the details load in the current tab, replacing the list.
It's not very practical for comparing two addons, for example.

## How This PR Solves The Issue

Test the event to open new tab when middle mous click or CTRL+tab is used.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

Fixes #10

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

