### PR TITLE
fix: add `overflow-x` for tables

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -53,11 +53,19 @@ pre {
     max-width: 100%;
 }
 
-#content-wrapper table,
+#content-wrapper table {
+    width: auto;
+    min-width: 100%;
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+    border: none;
+    border-collapse: collapse;
+}
+
 #content-wrapper th,
 #content-wrapper td {
     border: 1px solid black;
-    border-collapse: collapse;
     padding: 8px;
 }
 


### PR DESCRIPTION
## The Issue

Table here is too big in width https://addons.ddev.com/addons/ddev/ddev-minio

## How This PR Solves The Issue

Adds `overflow-x`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

