### PR TITLE
feat: render GitHub Admonitions, use Jekyll 4

### DIFF
--- a/.bundle/install
+++ b/.bundle/install
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# The first start may take a minute or two
-bundle install
-
-# Fix for LiveReload from Jekyll 4.x https://github.com/jekyll/jekyll/pull/8718
-# GitHub Pages use Jekyll 3.10.0 without a proper fix
-sed -i "s|<script src=\"http://|<script src=\"' + location.protocol + '//|" vendor/bundle/ruby/3.1.0/gems/jekyll-3.10.0/lib/jekyll/commands/serve/servlet.rb

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -32,6 +32,6 @@ web_extra_exposed_ports:
       https_port: 4010
 web_extra_daemons:
     - name: jekyll-dev-daemon
-      command: bash -c 'bash .bundle/install && touch /var/tmp/bundleinstalldone && bundle exec jekyll serve --host=0.0.0.0 --baseurl="" --livereload --livereload-port=4010'
+      command: bash -c 'bundle install && touch /var/tmp/bundleinstalldone && bundle exec jekyll serve --host=0.0.0.0 --baseurl="" --livereload --livereload-port=4010'
       directory: /var/www/html
 ddev_version_constraint: '>= v1.24.2'

--- a/.ddev/nginx_full/nginx-site.conf
+++ b/.ddev/nginx_full/nginx-site.conf
@@ -33,6 +33,11 @@ server {
         try_files $uri $uri/ $uri.html /index.php?$query_string;
     }
 
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    error_page 404 /404.html;
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -76,16 +76,25 @@ jobs:
         with:
           ref: main
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+
       - name: Setup Pages
+        id: pages
         uses: actions/configure-pages@v5
 
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./
-          destination: ./_site
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}" --verbose
+        env:
+          JEKYLL_ENV: production
 
       - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3
 
   # Deployment job

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,6 @@ group :jekyll_plugins do
   gem "jekyll-gist"
   gem "jekyll-feed"
   gem "jekyll-include-cache"
+  gem "jekyll-gfm-admonitions"
   gem "jemoji"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,7 @@
 source "https://rubygems.org"
 
-# This gem depends on Jekyll 3.10.0
-gem "github-pages", group: :jekyll_plugins
+gem "jekyll", group: :jekyll_plugins
 
-# List of supported plugins available at
-# https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#plugins
 group :jekyll_plugins do
-  gem "jekyll-paginate"
-  gem "jekyll-sitemap"
-  gem "jekyll-gist"
-  gem "jekyll-feed"
-  gem "jekyll-include-cache"
-  gem "jekyll-gfm-admonitions"
-  gem "jemoji"
+    gem "jekyll-gfm-admonitions"
 end

--- a/_config.yml
+++ b/_config.yml
@@ -46,6 +46,7 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jekyll-include-cache
+  - jekyll-gfm-admonitions
   - jemoji
 
 whitelist:
@@ -54,6 +55,7 @@ whitelist:
   - jekyll-gist
   - jekyll-feed
   - jekyll-include-cache
+  - jekyll-gfm-admonitions
   - jemoji
 
 defaults:

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,8 @@ title: DDEV Add-on Registry
 # baseurl should look like "/addon-registry" for repo ddev/addon-registry
 # it's empty, because we use custom domain
 baseurl: ""
+repository: ddev/addon-registry
+
 description: >-
   A registry for DDEV add-ons where users can discover,
   explore, and leave comments on available add-ons.
@@ -41,25 +43,9 @@ exclude:
   - vendor/
 
 plugins:
-  - jekyll-paginate
-  - jekyll-sitemap
-  - jekyll-gist
-  - jekyll-feed
-  - jekyll-include-cache
   - jekyll-gfm-admonitions
-  - jemoji
-
-whitelist:
-  - jekyll-paginate
-  - jekyll-sitemap
-  - jekyll-gist
-  - jekyll-feed
-  - jekyll-include-cache
-  - jekyll-gfm-admonitions
-  - jemoji
 
 defaults:
-  # _addons
   - scope:
       path: '_addons'
     values:


### PR DESCRIPTION
## The Issue

https://addons.ddev.com/addons/ddev/ddev-varnish

![image](https://github.com/user-attachments/assets/0495bd53-aae9-4e63-a07b-0635fcc730be)

GitHub Admonitions are not rendered.

## How This PR Solves The Issue

Adds `jekyll-gfm-admonitions`, but first we need to wait for a fix from:

- https://github.com/Helveg/jekyll-gfm-admonitions/pull/11

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

