### PR TITLE
fix: make GitHub spoilers render correctly, fixes #11

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -69,6 +69,11 @@ pre {
     padding: 8px;
 }
 
+#content-wrapper summary p {
+    display: inline;
+    margin-left: 0.5rem;
+}
+
 a:link, a:visited {
     color: $accent;
 }

--- a/go/main.go
+++ b/go/main.go
@@ -230,6 +230,9 @@ func getRepoReadme(repo *github.Repository) (string, error) {
 	// Replace relative links with full links
 	updatedContent := replaceRelativeLinks(content, repo)
 
+	// GitHub spoilers rendering
+	updatedContent = formatGitHubSpoilers(updatedContent)
+
 	return updatedContent, nil
 }
 
@@ -276,6 +279,13 @@ func replaceRelativeLinks(content string, repo *github.Repository) string {
 	})
 
 	return updatedContent
+}
+
+func formatGitHubSpoilers(content string) string {
+	return strings.NewReplacer(
+		`<details>`, `<details markdown="1">`,
+		`<summary>`, `<summary markdown="span">`,
+	).Replace(content)
 }
 
 // isFileChanged checks if a file has changed


### PR DESCRIPTION
## The Issue

- #11

## How This PR Solves The Issue

Using example from:

- https://github.com/gettalong/kramdown/issues/155#issuecomment-1024896918

I added markdown to GitHub spoilers.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

