### PR TITLE
fix: use strict title matching

### DIFF
--- a/_layouts/addon.html
+++ b/_layouts/addon.html
@@ -62,7 +62,7 @@ layout: index
         data-category="Add-on registry comments"
         data-category-id="DIC_kwDON5ODtM4Cm8gG"
         data-mapping="title"
-        data-strict="0"
+        data-strict="1"
         data-reactions-enabled="1"
         data-emit-metadata="0"
         data-input-position="top"


### PR DESCRIPTION
## The Issue

Comments are the same on both pages:

https://addons.ddev.com/addons/ddev/ddev-redis
https://addons.ddev.com/addons/ddev/ddev-redis-7

## How This PR Solves The Issue

Uses strict matching for titles.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

