### PR TITLE
refactor: don't show org name on the org page

### DIFF
--- a/_includes/addon_table.html
+++ b/_includes/addon_table.html
@@ -30,7 +30,7 @@
                 {%- if include.filter_by_user and addon.user != include.filter_by_user %}{% continue %}{% endif -%}
                 <tr>
                     <td class="name" data-url="{{ site.baseurl }}{{ addon.url }}">{{ addon.repo }}</td>
-                    <td class="description">[<a href="{{ site.baseurl }}/addons/{{ addon.user }}/">{{ addon.user }}</a>] {{ addon.description }}</td>
+                    <td class="description">{% unless include.filter_by_user %}[<a href="{{ site.baseurl }}/addons/{{ addon.user }}/">{{ addon.user }}</a>]{% endunless %} {{ addon.description }}</td>
                     <td class="updated_at" style="white-space: nowrap;">{{ addon.updated_at }}</td>
                     <td class="type">{% include addon_types_list.html addon=addon %}</td>
                     <td class="stars" data-order="{{ addon.stars | to_integer }}">


### PR DESCRIPTION
## The Issue

Sometimes when browsing add-ons, I navigate to an organization's page to view their add-ons. But when I'm done and try to do a global search, I forget that I'm still on the org page, so the search only returns results from that org.

## How This PR Solves The Issue

Removes the organization indicator from the description when viewing add-ons on an organization's page. This would make it clearer that I'm already browsing within the org context.

This link isn't necessary here, since it just navigates to the same page you're already on.

## Manual Testing Instructions

Before

![image](https://github.com/user-attachments/assets/3d58523a-8353-4af6-8f30-719a06dd4dc9)

After

![image](https://github.com/user-attachments/assets/fa74cd77-701b-4cf6-8df3-7c4d1113fa98)


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

