### PR TITLE
fix: exclude IDE folders from Jekyll analyze

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,9 +32,11 @@ exclude:
   - .ddev/
   - .git/
   - .github/
+  - .idea/
   - .jekyll-cache/
   - .sass-cache/
   - .jekyll-metadata
+  - .vscode/
   - Gemfile
   - Gemfile.lock
   - go


### PR DESCRIPTION
## The Issue

I see this locally in `ddev logs -f`

```
...
Regenerating: 1 file(s) changed at 2025-04-14 13:45:48
            .idea/workspace.xml
        GFMA: Converted admonitions in 289 file(s).
        GFMA: Inserting admonition CSS in 289 page(s).
        Error: undefined method `gsub!' for nil:NilClass page.output.gsub!(%r{<head>(.*?)</head>}m) do |match| ^^^^^^
        Error: Run jekyll build --trace for more information.
```

## How This PR Solves The Issue

Excludes `.idea/` and `.vscode/`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

