### PR TITLE
feat: add info about `ddev-get` topic

### DIFF
--- a/_includes/addon_table.html
+++ b/_includes/addon_table.html
@@ -1,5 +1,11 @@
 <p>
-    A registry for <a href="https://ddev.readthedocs.io/en/stable/users/extend/additional-services/" target="_blank">DDEV add-ons</a> where users can discover, explore, and leave comments on available add-ons.
+    A registry of <a href="https://ddev.readthedocs.io/en/stable/users/extend/additional-services/" target="_blank">DDEV add-ons</a> where users can discover, explore, and leave comments on available add-ons.
+</p>
+
+<p>
+    If you have an add-on but don't see it listed here, add the <code>ddev-get</code>
+    <a href="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics">topic</a>
+    to your GitHub repository.
 </p>
 
 {%- assign official_addons = site.addons | where_exp: "addon", "addon.group == nil" | where_exp: "addon", "addon.user == 'ddev'" | sort: "repo" -%}


### PR DESCRIPTION
## The Issue

People may not know about the `ddev-get` topic, as this information is explained deep down in the https://github.com/ddev/ddev-addon-template and https://ddev.readthedocs.io/en/stable/users/extend/additional-services/#creating-an-additional-service-for-ddev-add-on

## How This PR Solves The Issue

Adds a tip about this to the main page.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

