### PR TITLE
feat: implement redirect for `/addons/`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gem "jekyll", group: :jekyll_plugins
 
 group :jekyll_plugins do
     gem "jekyll-gfm-admonitions"
+    gem "jekyll-redirect-from"
 end

--- a/_config.yml
+++ b/_config.yml
@@ -46,6 +46,7 @@ exclude:
 
 plugins:
   - jekyll-gfm-admonitions
+  - jekyll-redirect-from
 
 defaults:
   - scope:

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 ---
 layout: page
 title: DDEV Add-on Registry
+redirect_from:
+    - /addons/
 ---
 
 {% include addon_table.html %}


### PR DESCRIPTION
## The Issue

This is a valid link https://addons.ddev.com/addons/ddev/

But this is 404 https://addons.ddev.com/addons/

![image](https://github.com/user-attachments/assets/508ff4cb-404c-49cc-9dd1-552d5a3969e4)

## How This PR Solves The Issue

Adds a redirect from `/addons/` to the main page.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

