### PR TITLE
fix: prevent page jumping when using pagination

### DIFF
--- a/_includes/addon_table.html
+++ b/_includes/addon_table.html
@@ -62,6 +62,13 @@
         },
         page: 24,
     });
+    document.addEventListener('click', function (e) {
+        if (e.target.classList.contains('page')) {
+            e.preventDefault();
+            const el = document.scrollingElement || document.documentElement;
+            el.scrollTo({ top: el.scrollHeight });
+        }
+    });
     if ((addonList.size() / addonList.page) <= 1) {
         document.getElementsByClassName('pagination')[0].style.display = 'none';
     }


### PR DESCRIPTION
## The Issue

Different add-on cards have different heights, which results in page jumping.

## How This PR Solves The Issue

Scrolls down to the bottom when using pagination.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

