### PR TITLE
fix: don't stretch add-on card to full width

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -231,7 +231,7 @@ button {
 
 .card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
     gap: 14px;
     align-items: stretch;
 }


### PR DESCRIPTION
## The Issue

When using search:

![image](https://github.com/user-attachments/assets/1a4b2df6-387e-4207-a2b7-b324ae455758)

## How This PR Solves The Issue

Don't stretch the card:

![image](https://github.com/user-attachments/assets/f512c247-25cd-4ecf-ab99-9c0ca2151767)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

