### PR TITLE
chore(giscus): disable reactions for the add-ons

### DIFF
--- a/_layouts/addon.html
+++ b/_layouts/addon.html
@@ -35,7 +35,7 @@ layout: index
         data-category-id="DIC_kwDON5ODtM4Cm8gG"
         data-mapping="title"
         data-strict="1"
-        data-reactions-enabled="1"
+        data-reactions-enabled="0"
         data-emit-metadata="0"
         data-input-position="top"
         data-theme="preferred_color_scheme"


### PR DESCRIPTION
## The Issue

When someone adds a first reaction to an add-on with Giscus, we receive an empty email. This is annoying.

## How This PR Solves The Issue

Disables these reactions.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

