### PR TITLE
docs: update DDEV documentation link

### DIFF
--- a/.ddev/nginx_full/nginx-site.conf
+++ b/.ddev/nginx_full/nginx-site.conf
@@ -8,7 +8,7 @@
 
 # If you want to take over this file and customize it, remove the line above
 # and ddev will respect it and won't overwrite the file.
-# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-nginx-configuration
+# See https://docs.ddev.com/en/stable/users/extend/customization-extendibility/#custom-nginx-configuration
 
 server {
     listen 80 default_server;

--- a/_includes/addon_table.html
+++ b/_includes/addon_table.html
@@ -1,5 +1,5 @@
 <div class="description">
-    A registry of <a href="https://ddev.readthedocs.io/en/stable/users/extend/additional-services/" target="_blank" title="Learn more about DDEV add-ons" aria-label="Learn more about DDEV add-ons">DDEV add-ons</a>
+    A registry of <a href="https://docs.ddev.com/en/stable/users/extend/additional-services/" target="_blank" title="Learn more about DDEV add-ons" aria-label="Learn more about DDEV add-ons">DDEV add-ons</a>
     where users can discover, explore, and leave comments on available add-ons.<br />
     If you have an add-on but don't see it listed here, add the <code>ddev-get</code>
     <a href="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics" target="_blank" title="Learn more about GitHub topics" aria-label="Learn more about GitHub topics">topic</a> to your GitHub repository.


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/pull/7552 PR moves the documentation from `ddev.readthedocs.io` to `/docs.ddev.com`

## How This PR Solves The Issue

This PR updates 2 of the URLS to DDEV documentation.

It does NOT update links in individual addons. (If I recall, we populate this through automation?)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

https://github.com/ddev/ddev/pull/7552

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

