### PR TITLE
refactor: use `/blog` for "Blog" link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
         <div class="nav-menu">
             <ul class="nav-links">
                 <li><a href="https://docs.ddev.com/" target="_blank" rel="noopener">Docs</a></li>
-                <li><a href="https://ddev.com/" target="_blank" rel="noopener">Blog</a></li>
+                <li><a href="https://ddev.com/blog/" target="_blank" rel="noopener">Blog</a></li>
                 <li><a href="https://github.com/ddev/ddev" target="_blank" rel="noopener">GitHub</a></li>
                 <li><a href="https://ddev.com/support-ddev/" target="_blank" rel="noopener">❤️ Support DDEV</a></li>
             </ul>


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/7566

## How This PR Solves The Issue

Changes the link for "Blog".

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

