### PR TITLE
feat: add skip_update_addons option and improve API degradation handling, for #47

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -41,10 +41,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Load 1password secret(s)
-        uses: 1password/load-secrets-action@v2
+        if: ${{ !inputs.skip_update_addons }}
+        uses: 1password/load-secrets-action@v3
         with:
           export-env: true
         env:
@@ -109,7 +110,7 @@ jobs:
     needs: update-addons
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 
@@ -132,7 +133,7 @@ jobs:
 
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
 
   # Deployment job
   deploy:


### PR DESCRIPTION
## The Issue

- #47

## How This PR Solves The Issue

- Adds `skip_update_addons` for easier deploy without updates.
- Doesn't fail on GitHub search API degradation, reverts deleted files.
- Bumps actions.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

