### PR TITLE
ci: ability to skip add-on update

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Load 1password secret(s)
-        if: ${{ !inputs.skip_update_addons }}
+        if: ${{ !inputs.skip_update_addons && !contains(github.event.head_commit.message, '[skip ci]') }}
         uses: 1password/load-secrets-action@v3
         with:
           export-env: true
@@ -59,14 +59,14 @@ jobs:
           limit-access-to-actor: true
 
       - name: Fetch add-on data with Go
-        if: ${{ !inputs.skip_update_addons }}
+        if: ${{ !inputs.skip_update_addons && !contains(github.event.head_commit.message, '[skip ci]') }}
         run: |
           cd go
           go mod vendor
           go run main.go
 
       - name: Check for GitHub search API degradation
-        if: ${{ !inputs.skip_update_addons }}
+        if: ${{ !inputs.skip_update_addons && !contains(github.event.head_commit.message, '[skip ci]') }}
         run: |
           # Check if any deleted addon repos still have the ddev-get topic (indicating search API issues)
           DELETED_ADDONS=$(git status --porcelain | grep '^.D.*\.md$' | sed 's|.D _addons/\([^/]*\)/\([^/]*\)\.md|\1/\2|')
@@ -100,12 +100,12 @@ jobs:
           fi
 
       - name: Commit and push changes
-        if: ${{ !inputs.skip_update_addons }}
+        if: ${{ !inputs.skip_update_addons && !contains(github.event.head_commit.message, '[skip ci]') }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add _addons/
-          git commit -m "Update addons [skip ci]" || echo "No changes to commit"
+          git commit -m "Update addons" || echo "No changes to commit"
           git push
 
   # Build job


### PR DESCRIPTION
## The Issue

Sometimes I need to push several commits, and I don't want to fetch and update add-ons in this case.

## How This PR Solves The Issue

Adds `[skip ci]` support.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

