### PR TITLE
feat: add scroll navigation to add-on pages, remove "Read more" button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ baseurl: ""
 repository: ddev/addon-registry
 
 # to purge old cache for js and css files
-clear_cache_date: 20250826
+clear_cache_date: 20250827
 
 description: >-
   A registry of DDEV add-ons where users can discover,

--- a/_layouts/addon.html
+++ b/_layouts/addon.html
@@ -4,29 +4,24 @@ layout: index
 
 {% include header.html page=page %}
 
-<div id="content-wrapper">
-    {%- assign split_content = content | split: '</p>' -%}
-    <!-- Display the first 3 paragraphs -->
-    <div id="visible-content">
-        {{ split_content | slice: 0, 3 | join: '</p>' | markdownify }}
-    </div>
+<div class="sort-buttons">
+    <button class="button-page" type="button" onclick="document.querySelector('.addon-comments').scrollIntoView({ behavior: 'smooth' })" title="Scroll to comments section" aria-label="Scroll to comments section">Comments</button>
+    <button class="button-page" type="button" onclick="window.open('{{ page.github_url }}', '_blank')" title="View add-on on GitHub" aria-label="View add-on on GitHub">View on GitHub <span class="github-icon github-icon-20" aria-hidden="true"></span></button>
+    <button class="button-page" type="button" onclick="window.open('{{ page.github_url }}/issues', '_blank')" title="Report an issue on GitHub" aria-label="Report an issue on GitHub">Report an issue <span class="github-icon github-icon-20" aria-hidden="true"></span></button>
+</div>
 
-    <!-- Hidden content that will be displayed on clicking "Read more" -->
-    <div id="hidden-content" style="display: none;">
-        {{ split_content | slice: 3, 1000 | join: '</p>' | markdownify }}
-    </div>
+<div id="content-wrapper">
+    {{ content }}
 </div>
 
 <div class="sort-buttons">
-    {%- if split_content.size > 4 -%}
-    <button class="button-page" type="button" id="read-more-btn" onclick="toggleContent()" title="Read more about add-on" aria-label="Read more about add-on">Read more</button>
-    {%- endif -%}
+    <button class="button-page" type="button" onclick="window.scrollTo({ top: 0, behavior: 'smooth' })" title="Scroll to top of page" aria-label="Scroll to top of page">Back to top</button>
     <button class="button-page" type="button" onclick="window.open('{{ page.github_url }}', '_blank')" title="View add-on on GitHub" aria-label="View add-on on GitHub">View on GitHub <span class="github-icon github-icon-20" aria-hidden="true"></span></button>
     <button class="button-page" type="button" onclick="window.open('{{ page.github_url }}/issues', '_blank')" title="Report an issue on GitHub" aria-label="Report an issue on GitHub">Report an issue <span class="github-icon github-icon-20" aria-hidden="true"></span></button>
 </div>
 <script src="{{ site.baseurl }}/assets/addon.js"></script>
 
-<div style="border-top: 1px solid #ddd; margin: 25px 0;"></div>
+<div style="border-top: 1px solid #ddd; margin: 25px 0;" class="addon-comments"></div>
 
 <script src="https://giscus.app/client.js"
         data-repo="ddev/giscus-comments"

--- a/assets/addon.js
+++ b/assets/addon.js
@@ -1,37 +1,3 @@
-function toggleContent(expand = false) {
-    const content = document.getElementById("hidden-content");
-    const btn = document.getElementById("read-more-btn");
-
-    if (content.style.display === "none" || expand) {
-        content.style.display = "block";
-        btn.textContent = "Read less";
-        btn.title = "Read less about add-on";
-        btn.ariaLabel = "Read less about add-on";
-    } else {
-        content.style.display = "none";
-        btn.textContent = "Read more";
-        btn.title = "Read more about add-on";
-        btn.ariaLabel = "Read more about add-on";
-    }
-    btn.blur();
-}
-
-function expandHash(hash) {
-    if (!hash) return;
-
-    const target = document.querySelector(hash);
-    const content = document.getElementById("hidden-content");
-
-    if (target && content && content.contains(target)) {
-        toggleContent(true);
-
-        // Wait for layout update, then scroll
-        setTimeout(() => {
-            target.scrollIntoView({ behavior: "smooth", block: "start" });
-        }, 100);
-    }
-}
-
 document.addEventListener("DOMContentLoaded", function () {
     // Add permalinks to headings
     document.querySelectorAll('h1, h2, h3, h4, h5').forEach((heading) => {
@@ -58,9 +24,6 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     });
 
-    // Expand hash on load
-    expandHash(window.location.hash);
-
     // Intercept internal anchor clicks
     document.querySelectorAll('a[href^="#"]').forEach(anchor => {
         anchor.addEventListener("click", (e) => {
@@ -68,13 +31,7 @@ document.addEventListener("DOMContentLoaded", function () {
             if (hash.length > 1 && document.querySelector(hash)) {
                 e.preventDefault();
                 history.pushState(null, '', hash); // update URL without reloading
-                expandHash(hash);
             }
         });
     });
-});
-
-// Handle hash changes (e.g. if user edits URL manually)
-window.addEventListener("hashchange", () => {
-    expandHash(window.location.hash);
 });


### PR DESCRIPTION
## The Issue

We have a "Read more" button. It was originally meant to hide the add-on text for easier access to comments.

However, people rarely leave comments, so pressing "Read more" every time is annoying.

## How This PR Solves The Issue

Replaces the "Read more" button with a "Comments" button that scrolls directly to the comments section.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

