### PR TITLE
feat: add shareable search URLs with fuzzy matching, fixes #51

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ baseurl: ""
 repository: ddev/addon-registry
 
 # to purge old cache for js and css files
-clear_cache_date: 20250827
+clear_cache_date: 20251007
 
 description: >-
   A registry of DDEV add-ons where users can discover,

--- a/assets/addon-list.js
+++ b/assets/addon-list.js
@@ -30,23 +30,169 @@ document.addEventListener('DOMContentLoaded', function () {
         if (pagination) pagination.style.display = 'none';
     }
 
-    // Search input filtering
-    let previousValue = "";
+    // URL parameter handling
     const searchInput = document.getElementById('addon-search');
 
+    function updateURL(searchTerm) {
+        const url = new URL(window.location);
+        if (searchTerm) {
+            url.searchParams.set('search', searchTerm);
+        } else {
+            url.searchParams.delete('search');
+        }
+        window.history.replaceState({}, '', url);
+    }
+
+    // Fuzzy match algorithm (Bitap-like)
+    function fuzzyMatch(str, pattern, options) {
+        options = options || {};
+        const location = options.location || 0;
+        const distance = options.distance || 100;
+        const threshold = options.threshold || 0.4;
+
+        if (pattern === str) return true;
+        if (pattern.length > 32) return false;
+
+        // Build alphabet pattern
+        const patternAlphabet = {};
+        for (let i = 0; i < pattern.length; i++) {
+            patternAlphabet[pattern.charAt(i)] = 0;
+        }
+        for (let i = 0; i < pattern.length; i++) {
+            patternAlphabet[pattern.charAt(i)] |= 1 << (pattern.length - i - 1);
+        }
+
+        function bitapScore(errors, x) {
+            const accuracy = errors / pattern.length;
+            const proximity = Math.abs(location - x);
+            if (!distance) return proximity ? 1.0 : accuracy;
+            return accuracy + (proximity / distance);
+        }
+
+        let scoreThreshold = threshold;
+        let bestLoc = str.indexOf(pattern, location);
+        if (bestLoc !== -1) {
+            scoreThreshold = Math.min(bitapScore(0, bestLoc), scoreThreshold);
+            bestLoc = str.lastIndexOf(pattern, location + pattern.length);
+            if (bestLoc !== -1) {
+                scoreThreshold = Math.min(bitapScore(0, bestLoc), scoreThreshold);
+            }
+        }
+
+        const matchmask = 1 << (pattern.length - 1);
+        bestLoc = -1;
+
+        let binMin, binMid;
+        let binMax = pattern.length + str.length;
+        let lastRd;
+
+        for (let d = 0; d < pattern.length; d++) {
+            binMin = 0;
+            binMid = binMax;
+            while (binMin < binMid) {
+                if (bitapScore(d, location + binMid) <= scoreThreshold) {
+                    binMin = binMid;
+                } else {
+                    binMax = binMid;
+                }
+                binMid = Math.floor((binMax - binMin) / 2 + binMin);
+            }
+
+            binMax = binMid;
+            let start = Math.max(1, location - binMid + 1);
+            const finish = Math.min(location + binMid, str.length) + pattern.length;
+
+            const rd = Array(finish + 2);
+            rd[finish + 1] = (1 << d) - 1;
+
+            for (let j = finish; j >= start; j--) {
+                const charMatch = patternAlphabet[str.charAt(j - 1)];
+                if (d === 0) {
+                    rd[j] = ((rd[j + 1] << 1) | 1) & charMatch;
+                } else {
+                    rd[j] = (((rd[j + 1] << 1) | 1) & charMatch) | (((lastRd[j + 1] | lastRd[j]) << 1) | 1) | lastRd[j + 1];
+                }
+                if (rd[j] & matchmask) {
+                    const score = bitapScore(d, j - 1);
+                    if (score <= scoreThreshold) {
+                        scoreThreshold = score;
+                        bestLoc = j - 1;
+                        if (bestLoc <= location) {
+                            break;
+                        }
+                        start = Math.max(1, 2 * location - bestLoc);
+                    }
+                }
+            }
+
+            if (bitapScore(d + 1, location) > scoreThreshold) {
+                break;
+            }
+            lastRd = rd;
+        }
+
+        return bestLoc >= 0;
+    }
+
+    // Custom search with fuzzy matching
+    function performFuzzySearch(searchTerm) {
+        if (!searchTerm) {
+            addonList.filter();
+            addonList.search();
+            return;
+        }
+
+        const terms = searchTerm.trim().split(/\s+/);
+
+        addonList.filter(function(item) {
+            const name = item.values().name.toLowerCase();
+            const description = item.values().description.toLowerCase();
+
+            // Check if ALL terms match (either in name or description)
+            for (let term of terms) {
+                const termLower = term.toLowerCase();
+
+                // Try exact match first (faster)
+                if (name.includes(termLower) || description.includes(termLower)) {
+                    continue; // This term matches, check next term
+                }
+
+                // Try fuzzy match
+                const nameMatch = fuzzyMatch(name, termLower, {
+                    location: 0,
+                    distance: 100,
+                    threshold: 0.4
+                });
+                const descMatch = fuzzyMatch(description, termLower, {
+                    location: 0,
+                    distance: 100,
+                    threshold: 0.4
+                });
+
+                if (!nameMatch && !descMatch) {
+                    return false; // This term doesn't match, filter out this item
+                }
+            }
+
+            // All terms matched
+            return true;
+        });
+    }
+
+    // Manual fuzzy search with URL updates
     if (searchInput) {
         searchInput.addEventListener('input', function (e) {
-            const currentValue = e.target.value;
-            if (previousValue && currentValue === '') {
-                addonList.filter();
-            } else {
-                const searchTerm = currentValue.toLowerCase();
-                addonList.filter(function (item) {
-                    return item.values().name.toLowerCase().includes(searchTerm) ||
-                        item.values().description.toLowerCase().includes(searchTerm);
-                });
-            }
-            previousValue = currentValue;
+            const searchTerm = e.target.value;
+            performFuzzySearch(searchTerm);
+            updateURL(searchTerm);
         });
+    }
+
+    // Check for search parameter in URL on page load
+    const urlParams = new URLSearchParams(window.location.search);
+    const searchParam = urlParams.get('search');
+    if (searchParam && searchInput) {
+        searchInput.value = searchParam;
+        performFuzzySearch(searchParam);
     }
 });


### PR DESCRIPTION
## The Issue

- #51

## How This PR Solves The Issue

- Add URL parameter support (?search=term) for shareable search links
- Implement Bitap fuzzy matching algorithm for typo tolerance
- Search across both addon name and description fields
- Support multi-word search with AND logic (all terms must match)
- Optimize with exact match before fuzzy matching
- Update URL in real-time as user types
- Clear filters properly when search is deleted
- Update cache-busting timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

