### PR TITLE
Improve registry UX: star nudge, admonitions, and resource links, fixes #72

### DIFF
--- a/_includes/addon_table.html
+++ b/_includes/addon_table.html
@@ -1,8 +1,12 @@
 <div class="description">
-    A registry of <a href="https://docs.ddev.com/en/stable/users/extend/additional-services/" target="_blank" title="Learn more about DDEV add-ons" aria-label="Learn more about DDEV add-ons">DDEV add-ons</a>
-    where users can discover, explore, and leave comments on available add-ons.<br />
-    If you have an add-on but don't see it listed here, add the <code>ddev-get</code>
-    <a href="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics" target="_blank" title="Learn more about GitHub topics" aria-label="Learn more about GitHub topics">topic</a> to your GitHub repository.
+    <p>
+        A registry of <a href="https://docs.ddev.com/en/stable/users/extend/additional-services/" target="_blank" title="Learn more about DDEV add-ons" aria-label="Learn more about DDEV add-ons">DDEV add-ons</a>
+        where users can discover, explore, and leave comments on available add-ons.
+    </p>
+    <p>
+        Add the <code>ddev-get</code> <a href="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics" target="_blank" title="Learn more about GitHub topics" aria-label="Learn more about GitHub topics">topic</a> to your GitHub repo to list it here.
+        To build your own, see <a href="https://docs.ddev.com/en/stable/users/extend/creating-add-ons/" target="_blank" title="Creating DDEV Add-ons" aria-label="Creating DDEV Add-ons">Creating DDEV Add-ons</a> and the <a href="https://ddev.com/blog/ddev-add-on-maintenance-guide/" target="_blank" title="DDEV Add-on Maintenance Guide" aria-label="DDEV Add-on Maintenance Guide">maintenance guide</a>.
+    </p>
 </div>
 
 {%- assign official_addons = site.addons | where_exp: "addon", "addon.group == nil" | where_exp: "addon", "addon.user == 'ddev'" | sort: "repo" -%}
@@ -68,7 +72,7 @@
                             </object>
                         </div>
                         <div class="footer-item">
-                            <span class="stars">⭐ {{ addon.stars | to_integer }}</span>
+                            <object><a href="{{ addon.github_url }}" class="stars" tabindex="-1" target="_blank" title="Find it useful? Star it on GitHub!" style="color: inherit; text-decoration: none;">⭐ {{ addon.stars | to_integer }}</a></object>
                         </div>
                     </div>
                 </a>

--- a/_layouts/addon.html
+++ b/_layouts/addon.html
@@ -10,6 +10,10 @@ layout: index
     <button class="button-page" type="button" onclick="window.open('{{ page.github_url }}/issues', '_blank')" title="Report an issue on GitHub" aria-label="Report an issue on GitHub">Report an issue <span class="github-icon github-icon-20" aria-hidden="true"></span></button>
 </div>
 
+<div class="markdown-alert markdown-alert-tip">
+    <p>If you find this add-on useful, please <a href="{{ page.github_url }}">star it on GitHub</a> — stars show appreciation and help maintainers know their work matters.</p>
+</div>
+
 <div id="content-wrapper">
     {{ content }}
 </div>
@@ -19,6 +23,11 @@ layout: index
     <button class="button-page" type="button" onclick="window.open('{{ page.github_url }}', '_blank')" title="View add-on on GitHub" aria-label="View add-on on GitHub">View on GitHub <span class="github-icon github-icon-20" aria-hidden="true"></span></button>
     <button class="button-page" type="button" onclick="window.open('{{ page.github_url }}/issues', '_blank')" title="Report an issue on GitHub" aria-label="Report an issue on GitHub">Report an issue <span class="github-icon github-icon-20" aria-hidden="true"></span></button>
 </div>
+
+<div class="markdown-alert markdown-alert-tip">
+    <p>If you find this add-on useful, please <a href="{{ page.github_url }}">star it on GitHub</a> — stars show appreciation and help maintainers know their work matters.</p>
+</div>
+
 <script src="{{ site.baseurl }}/assets/addon.js"></script>
 
 <div style="border-top: 1px solid #ddd; margin: 25px 0;" class="addon-comments"></div>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -643,3 +643,51 @@ pre {
     display: inline;
     margin-left: 0.5rem;
 }
+
+.markdown-alert {
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+    color: inherit;
+    border-left: .25em solid #30363d;
+
+    > :first-child { margin-top: 0; }
+    > :last-child { margin-bottom: 0; }
+
+    .markdown-alert-title {
+        display: flex;
+        font-weight: 500;
+        align-items: center;
+        line-height: 1;
+        margin-bottom: 0.5rem;
+    }
+
+    svg {
+        margin-right: 0.5rem !important;
+        path { fill: currentColor; }
+    }
+
+    &.markdown-alert-note {
+        border-left-color: #4493f8;
+        .markdown-alert-title { color: #4493f8; }
+    }
+
+    &.markdown-alert-important {
+        border-left-color: #ab7df8;
+        .markdown-alert-title { color: #ab7df8; }
+    }
+
+    &.markdown-alert-warning {
+        border-left-color: #9e6a03;
+        .markdown-alert-title { color: #d29922; }
+    }
+
+    &.markdown-alert-tip {
+        border-left-color: #238636;
+        .markdown-alert-title { color: #3fb950; }
+    }
+
+    &.markdown-alert-caution {
+        border-left-color: #da3633;
+        .markdown-alert-title { color: #f85149; }
+    }
+}


### PR DESCRIPTION
## The Issue

- Fixes #72

## How This PR Solves The Issue

- Add tip admonition on each add-on page encouraging users to star it on GitHub
- Add global admonition CSS so styles are always available (not just on pages with markdown admonitions)
- Improve registry description and add tip with links to Creating DDEV Add-ons and the maintenance guide
- Make star count on cards a link to the GitHub repo with a hover tooltip

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

