### PR TITLE
feat(ci): push add-on snapshots to history branch instead of main, fixes #74

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## The Issue
+
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
+
+<!-- Provide a brief description of the issue. -->
+
+## How This PR Solves The Issue
+
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
+## Manual Testing Instructions
+
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
+
+## Automated Testing Overview
+
+<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
+
+## Release/Deployment Notes
+
+<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -41,11 +41,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Load 1password secret(s)
         if: ${{ !inputs.skip_update_addons && !contains(github.event.head_commit.message, '[skip update]') }}
-        uses: 1password/load-secrets-action@v3
+        uses: 1password/load-secrets-action@v4
         with:
           export-env: true
         env:
@@ -58,6 +58,12 @@ jobs:
         with:
           limit-access-to-actor: true
 
+      - name: Fetch existing add-ons from history branch
+        if: ${{ !inputs.skip_update_addons && !contains(github.event.head_commit.message, '[skip update]') }}
+        run: |
+          git fetch origin history
+          git checkout origin/history -- _addons/ || echo "No existing _addons in history branch"
+
       - name: Fetch add-on data with Go
         if: ${{ !inputs.skip_update_addons && !contains(github.event.head_commit.message, '[skip update]') }}
         run: |
@@ -68,7 +74,7 @@ jobs:
       - name: Check for GitHub search API degradation
         if: ${{ !inputs.skip_update_addons && !contains(github.event.head_commit.message, '[skip update]') }}
         run: |
-          # Check if any deleted addon repos still have the ddev-get topic (indicating search API issues)
+          # Check if any deleted add-on repos still have the ddev-get topic (indicating search API issues)
           DELETED_ADDONS=$(git status --porcelain | grep '^.D.*\.md$' | sed 's|.D _addons/\([^/]*\)/\([^/]*\)\.md|\1/\2|')
 
           if [ -n "$DELETED_ADDONS" ]; then
@@ -141,8 +147,8 @@ jobs:
                 ADDON_FILE="_addons/$repo.md"
                 OWNER=$(echo "$repo" | cut -d'/' -f1)
                 OWNER_INDEX="_addons/$OWNER/index.html"
-                git checkout HEAD -- "$ADDON_FILE" || { echo "Could not restore $ADDON_FILE"; exit 1; }
-                git checkout HEAD -- "$OWNER_INDEX" || { echo "Could not restore $OWNER_INDEX"; exit 1; }
+                git checkout origin/history -- "$ADDON_FILE" || { echo "Could not restore $ADDON_FILE"; exit 1; }
+                git checkout origin/history -- "$OWNER_INDEX" || { echo "Could not restore $OWNER_INDEX"; exit 1; }
                 echo "Files $ADDON_FILE and $OWNER_INDEX have been restored."
               elif [ "$SHOULD_DELETE" = true ]; then
                 echo "$REASON, safe to delete."
@@ -152,14 +158,34 @@ jobs:
             echo "No add-on deletions detected."
           fi
 
-      - name: Commit and push changes
+      - name: Commit and push add-ons to history branch
         if: ${{ !inputs.skip_update_addons && !contains(github.event.head_commit.message, '[skip update]') }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Use a worktree to commit to history without switching branches
+          git worktree add /tmp/history-worktree origin/history
+          rm -rf /tmp/history-worktree/_addons/
+          cp -r _addons/ /tmp/history-worktree/_addons/
+
+          cd /tmp/history-worktree
+          SNAPSHOT_DATE=$(date +%F)
           git add _addons/
-          git commit -m "Update addons [skip ci]" || echo "No changes to commit"
-          git push
+          if ! git diff --cached --quiet; then
+            LAST_MSG=$(git log -1 --pretty=%s)
+            if echo "$LAST_MSG" | grep -q "snapshot ${SNAPSHOT_DATE}"; then
+              git commit --amend --no-edit
+              git push origin history --force-with-lease
+            else
+              git commit -m "chore(add-ons): snapshot ${SNAPSHOT_DATE}"
+              git push origin history
+            fi
+          else
+            echo "No changes to commit"
+          fi
+
+          git worktree remove /tmp/history-worktree
 
   # Build job
   build:
@@ -167,9 +193,14 @@ jobs:
     needs: update-addons
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: main
+
+      - name: Fetch add-ons from history branch
+        run: |
+          git fetch origin history
+          git checkout origin/history -- _addons/
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -180,7 +211,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
@@ -190,7 +221,7 @@ jobs:
 
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
 
   # Deployment job
   deploy:
@@ -202,4 +233,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## The Issue

- Fixes #74

Automated add-on updates were committed directly to main, making it hard to distinguish manual changes from bot-generated snapshot noise and leaving main open to direct bot pushes.

## How This PR Solves The Issue

- Before running Go, fetch `_addons/` from `origin/history` into the index so the degradation check can diff against the previous snapshot
- After Go regenerates `_addons/`, commit it to the `history` branch via a git worktree (no branch switching in the main worktree)
- Same-day re-runs amend the existing snapshot commit and force-with-lease push instead of creating a duplicate
- Restore commands in the degradation check updated from `git checkout HEAD` to `git checkout origin/history`
- Build job fetches `_addons/` from `origin/history` before Jekyll runs so it always builds from the latest snapshot regardless of skip flags
- Bump all GitHub Actions versions (checkout, pages, artifact, deploy)

## Manual Testing Instructions

Trigger the workflow via `workflow_dispatch` and verify:
- `history` branch receives a `chore(add-ons): snapshot YYYY-MM-DD` commit
- `main` branch receives no new bot commits
- GitHub Pages deploys successfully with full add-on data
- Re-running on the same day amends rather than adds a second commit

## Automated Testing Overview

No automated tests - this is CI/CD pipeline logic only.

## Release/Deployment Notes

The `history` branch must exist and contain `_addons/` before this workflow runs (already satisfied: branch was seeded in commit 6b44bc0).
