### PR TITLE
fix: bypass .gitignore for _addons and restore them on `ddev start`

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,20 +1,22 @@
 type: php
 docroot: _site
 webserver_type: nginx-fpm
-xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
 hooks:
     post-start:
         - exec: bash -c 'while [ ! -f /var/tmp/bundleinstalldone ]; do sleep 1; done'
         - exec: bash -c 'bundle exec jekyll build --baseurl=""'
-        - exec: echo -e "                                  NOTICE                                        \n
-            =================================================================================\n
-            =================================================================================\n
-            The Jekyll dev container is ready \n LiveReload is available at \e[32m${DDEV_PRIMARY_URL}:4000\e[0m \n
-            To troubleshoot any issues run \e[35mddev describe\e[0m or \e[35mddev logs --follow --time\e[0m\n"
+        - exec: echo -e "                                  NOTICE                                        "
+        - exec: echo -e "================================================================================"
+        - exec: echo -e "The Jekyll dev container is ready"
+        - exec: echo -e "LiveReload is available at \e[32m${DDEV_PRIMARY_URL_WITHOUT_PORT}:4000\e[0m"
+        - exec: echo -e "To troubleshoot any issues run \e[35mddev describe\e[0m or \e[35mddev logs --follow --time\e[0m"
+        - exec: echo -e "================================================================================"
     pre-start:
         - exec-host: ([ -d vendor ] && [ -f Gemfile.lock ]) || echo "The first start may take a minute or two..."
+        - exec-host: git fetch "$(git config branch.$(git branch --show-current).remote 2>/dev/null || git remote | head -1)" history || true
+        - exec-host: git restore --source=FETCH_HEAD --worktree -- _addons/ || echo "Could not restore _addons from history branch"
 omit_containers: [db]
 use_dns_when_possible: true
 web_environment: []
@@ -31,4 +33,5 @@ web_extra_daemons:
     - name: jekyll-dev-daemon
       command: bash -c 'bundle install && touch /var/tmp/bundleinstalldone && bundle exec jekyll serve --host=0.0.0.0 --baseurl="" --livereload --livereload-port=4010'
       directory: /var/www/html
+disable_upload_dirs_warning: true
 ddev_version_constraint: '>= v1.24.10'

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -171,7 +171,7 @@ jobs:
 
           cd /tmp/history-worktree
           SNAPSHOT_DATE=$(date +%F)
-          git add _addons/
+          git add -f _addons/
           if ! git diff --cached --quiet; then
             LAST_MSG=$(git log -1 --pretty=%s)
             if echo "$LAST_MSG" | grep -q "snapshot ${SNAPSHOT_DATE}"; then


### PR DESCRIPTION
## The Issue

https://github.com/ddev/addon-registry/actions/runs/26115526420/job/76803666393

```
Preparing worktree (detached HEAD ba7fdb2)
HEAD is now at ba7fdb2 chore(add-ons): snapshot 2026-05-19
The following paths are ignored by one of your .gitignore files:
_addons
hint: Use -f if you really want to add them.
```

## How This PR Solves The Issue

- Use `git add -f` in the history worktree so `_addons/` (which is in `.gitignore`) can be committed to the history branch
- Add pre-start exec-host hooks to fetch and restore `_addons/` from the history branch before Jekyll builds locally, so `ddev start` produces a full site; fetch is best-effort (offline-safe via fallback)
- Split the post-start NOTICE echo into separate exec lines for clarity

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
