### PR TITLE
fix(ci): push detached HEAD to history ref and drop worktree cleanup

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -176,16 +176,14 @@ jobs:
             LAST_MSG=$(git log -1 --pretty=%s)
             if echo "$LAST_MSG" | grep -q "snapshot ${SNAPSHOT_DATE}"; then
               git commit --amend --no-edit
-              git push origin history --force-with-lease
+              git push origin HEAD:history --force-with-lease
             else
               git commit -m "chore(add-ons): snapshot ${SNAPSHOT_DATE}"
-              git push origin history
+              git push origin HEAD:history
             fi
           else
             echo "No changes to commit"
           fi
-
-          git worktree remove /tmp/history-worktree
 
   # Build job
   build:


### PR DESCRIPTION
## The Issue

https://github.com/ddev/addon-registry/actions/runs/26116848062/job/76808231099

```
Preparing worktree (detached HEAD ba7fdb2)
HEAD is now at ba7fdb2 chore(add-ons): snapshot 2026-05-19
[detached HEAD 87932d2] chore(add-ons): snapshot 2026-05-19
 Date: Tue May 19 00:55:31 2026 +0000
 21 files changed, 297 insertions(+), 144 deletions(-)
 create mode 100644 _addons/e0ipso/ddev-assistant-opencode.md
error: src refspec history does not match any
error: failed to push some refs to 'https://github.com/ddev/addon-registry'
```

## How This PR Solves The Issue

- Push via HEAD:history so the push works from a detached HEAD worktree
- Remove the git worktree remove call: the runner discards /tmp anyway

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
