### PR TITLE
chore: clarify history branch and ddev-get topic guidance [skip update]

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Here's a breakdown of where important content and configuration files live:
 - **`.bundle`**: Contains config for local bundler.
 - **`.ddev`**: The DDEV configuration directory.
 - **`.github`**: The GitHub workflows that handle the deployment process.
-- **`_addons`**: Custom Jekyll collection that holds all the add-ons fetched from the community.
+- **`_addons`**: Custom Jekyll collection that holds all the add-ons with the `ddev-get` topic. Stored on the [`history` branch](https://github.com/ddev/addon-registry/commits/history/).
 - **`_data`**: User-defined Jekyll data types.
 - **`_includes`**: HTML partials used across the site.
 - **`_layouts`**: The layout templates for Jekyll pages.
@@ -57,3 +57,5 @@ Here's a breakdown of where important content and configuration files live:
 - **`_config.yml`**: The main configuration file for the Jekyll site.
 - **`addons.json`**: A JSON representation of all the DDEV add-ons.
 - **`index.html`**: The homepage of the registry.
+
+The [`history` branch](https://github.com/ddev/addon-registry/commits/history/) stores daily snapshots of `_addons` committed by CI.

--- a/_includes/addon_table.html
+++ b/_includes/addon_table.html
@@ -4,7 +4,9 @@
         where users can discover, explore, and leave comments on available add-ons.
     </p>
     <p>
-        Add the <code>ddev-get</code> <a href="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics" target="_blank" title="Learn more about GitHub topics" aria-label="Learn more about GitHub topics">topic</a> to your GitHub repo to list it here.
+        Add the <code>ddev-get</code> <a href="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics" target="_blank" title="Learn more about GitHub topics" aria-label="Learn more about GitHub topics">topic</a> to your GitHub repo to list it here when it's mature and intended for public use.
+    </p>
+    <p>
         To build your own, see <a href="https://docs.ddev.com/en/stable/users/extend/creating-add-ons/" target="_blank" title="Creating DDEV Add-ons" aria-label="Creating DDEV Add-ons">Creating DDEV Add-ons</a> and the <a href="https://ddev.com/blog/ddev-add-on-maintenance-guide/" target="_blank" title="DDEV Add-on Maintenance Guide" aria-label="DDEV Add-on Maintenance Guide">maintenance guide</a>.
     </p>
 </div>


### PR DESCRIPTION
## The Issue

https://github.com/ddev/addon-registry/issues/74#issuecomment-4488506714

> Related: We should stop making the addition of `ddev-get` topic a standard thing to do and suggest that it should be added based on the intended audience and the current maturity.

## How This PR Solves The Issue

- Add `_addons` note in README pointing to the history branch, where daily CI snapshots live (not present in main)
- Qualify the ddev-get topic prompt on the registry homepage: only add it when the add-on is mature and intended for public use

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
